### PR TITLE
SUB-5214 Replace x-frame-options header with CSP frame-ancestors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,13 +34,11 @@ const ContentSecurityPolicy = `
   script-src-elem 
   'self' 'unsafe-inline'
   *.google.com;
+
+  frame-ancestors 'none'; 
 `;
 
 const securityHeaders = [
-  {
-    key: "X-Frame-Options",
-    value: "DENY",
-  },
   {
     key: "Content-Security-Policy",
     value: ContentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),


### PR DESCRIPTION
**Description:**
Add content-security-policy frame-ancestors.

**Changes Made:**
- Add the header

**Issue(s) Resolved:**
https://ampion.atlassian.net/browse/SUB-5214

**Testing:**
Go to http://monitor.ampion.net/ or monitor.staging.ampion.net http://monitor.staging.ampion.net/ and check that the header has changed.